### PR TITLE
Fix to Nucleo CAN communication

### DIFF
--- a/nucleo/Inc/main.h
+++ b/nucleo/Inc/main.h
@@ -72,7 +72,7 @@
 
 /* USER CODE BEGIN Private defines */
 #define PERIOD_UPDATE_CMD 20 // Period in ms to update motor commands
-#define PERIOD_SEND_MES 100 // Period in ms to send data
+#define PERIOD_SEND_MES 20000 // Period to send data -> 100 = 1ms
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus

--- a/nucleo/Src/stm32f1xx_it.c
+++ b/nucleo/Src/stm32f1xx_it.c
@@ -94,11 +94,11 @@ void SysTick_Handler(void)
 	cmpt_cmd ++;
 	cmpt_can ++;
 	
-	if (cmpt_cmd % PERIOD_UPDATE_CMD){
+	if (cmpt_cmd == PERIOD_UPDATE_CMD){
 		UPDATE_CMD_FLAG = 1;
 		cmpt_cmd = 0;
 	}
-	if (cmpt_can % PERIOD_SEND_MES){
+	if (cmpt_can == PERIOD_SEND_MES){
 		SEND_CAN = 1;
 		cmpt_can = 0;
 	}


### PR DESCRIPTION
Ce commit répare la communication et l'envoi de message de la carte Nucléo sur le CAN. Il y avait une erreur dans le USER CODE du fichier stm32f1xx_it.c, la condition d'entrée des if étaient & (ce qui les faisait entrer à chaque itération) alors qu'il faut un == afin d'entrer dans le if uniquement lorsque le compter atteint la valeur de RELOAD.
La modification dans le main.h sert à fixer l'envoi des messages tous les 200ms